### PR TITLE
docs: use front-end API connection as example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ Import the provider like this in your entrypoint file (typically index.svelte):
 	});
 
 	const config = {
-		url: 'https://HOSTNAME/proxy',
-		clientKey: 'PROXYKEY',
+		url: 'https://UNLEASH-INSTANCE/api/frontend',
+		clientKey: 'CLIENT—SIDE—API—TOKEN',
 		refreshInterval: 15,
 		appName: 'your-app-name',
-		environment: 'dev'
 	};
 </script>
 
@@ -55,11 +54,10 @@ Alternatively, you can pass your own client in to the FlagProvider:
 	});
 
 	const config = {
-		url: 'https://HOSTNAME/proxy',
-		clientKey: 'PROXYKEY',
+		url: 'https://UNLEASH-INSTANCE/api/frontend',
+		clientKey: 'CLIENT—SIDE—API—TOKEN',
 		refreshInterval: 15,
 		appName: 'your-app-name',
-		environment: 'dev'
 	};
 
 	const client = new UnleashClient(config);


### PR DESCRIPTION
## What

This change makes the examples connect to the front-end API instead of
to the proxy. We want to push people towards using the front-end API
first, so changing the examples is a good place to start.

It also removes the `environment` property from initialization. This
property is (should be?) deprecated and generally just serves to confuse users, so
by removing it from the  examples, we can probably avoid a bit of confusion.