### PR TITLE
feat: prepare for 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"files": [
 		"package"
 	],
+	"main": "package/index.js",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/src/components/HelloWorld.svelte
+++ b/src/components/HelloWorld.svelte
@@ -3,8 +3,8 @@
 
 	import { useFlag, useFlagsStatus, useVariant } from '$lib';
 
-	const enabled = useFlag('test-feature');
-	const variant = useVariant('test-feature');
+	const enabled = useFlag('svelte-test-feature');
+	const variant = useVariant('svelte-test-feature');
 	const { flagsReady } = useFlagsStatus();
 </script>
 
@@ -32,11 +32,6 @@
 
 	<p>
 		Visit <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.
-	</p>
-
-	<p>
-		Check out <a href="https://github.com/sveltejs/kit#readme">SvelteKit</a> for the officially supported
-		framework, also powered by Vite!
 	</p>
 </main>
 

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,11 @@
+html, body {
+  margin: 0;
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,1 +1,16 @@
-export const ContextStateSymbol = Symbol('Context state identifier')
+import type { Writable } from 'svelte/store';
+import type { IContext, IVariant, UnleashClient } from 'unleash-proxy-client';
+
+export const ContextStateSymbol = Symbol('Context state identifier');
+
+export type eventArgs = [Function, any];
+
+export type TContext = {
+	on: (event: string, ...args: eventArgs) => void;
+	updateContext: (context: IContext) => Promise<void>;
+	isEnabled: (name: string) => boolean | undefined;
+	getVariant: (name: string) => IVariant | undefined;
+	client: Writable<UnleashClient | undefined>;
+	flagsReady: Writable<boolean>;
+	flagsError: Writable<any | null>;
+};

--- a/src/lib/useFlagsStatus.ts
+++ b/src/lib/useFlagsStatus.ts
@@ -1,8 +1,8 @@
 import { getContext } from 'svelte';
-import { ContextStateSymbol } from './context';
+import { ContextStateSymbol, type TContext } from './context';
 
 const useFlagsStatus = () => {
-	const { flagsReady, flagsError } = getContext(ContextStateSymbol);
+	const { flagsReady, flagsError } = getContext<TContext>(ContextStateSymbol);
 
 	return { flagsReady, flagsError };
 };

--- a/src/lib/useUnleashClient.ts
+++ b/src/lib/useUnleashClient.ts
@@ -1,12 +1,11 @@
 import { getContext } from 'svelte';
 import { get } from 'svelte/store';
-import { ContextStateSymbol } from './context';
-import type { UnleashClient } from 'unleash-proxy-client';
+import { ContextStateSymbol, type TContext } from './context';
 
 const useUnleashClient = () => {
-	const { client } = getContext(ContextStateSymbol);
+	const { client } = getContext<TContext>(ContextStateSymbol);
 
-	return get(client) as UnleashClient;
+	return get(client);
 };
 
 export default useUnleashClient;

--- a/src/lib/useUnleashContext.ts
+++ b/src/lib/useUnleashContext.ts
@@ -1,8 +1,8 @@
 import { getContext } from 'svelte';
-import { ContextStateSymbol } from './context';
+import { ContextStateSymbol, type TContext } from './context';
 
 const useUnleashContext = () => {
-	const { updateContext } = getContext(ContextStateSymbol);
+	const { updateContext } = getContext<TContext>(ContextStateSymbol);
 
 	return updateContext;
 };

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,23 +1,19 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import HelloWorld from '../components/HelloWorld.svelte';
 
-	let FlagProvider;
+	import '../global.css';
 
-	onMount(async () => {
-		const proxyClientSvelte = await import('$lib');
-		({ FlagProvider } = proxyClientSvelte);
-	});
+	import { FlagProvider } from '$lib';
 
 	const config = {
-		url: 'https://unleash-proxy.nunogois.com/proxy',
-		clientKey: 'ng-unleash-secret',
+		url: 'https://app.unleash-hosted.com/demo/api/frontend',
+		clientKey:
+			'proxy-client-svelte:development.f7d5c2f3633769afea4eadecd6bf46194dccec9c75170930c76ab4f0',
 		refreshInterval: 2,
-		appName: 'unleash-test',
-		environment: 'dev'
+		appName: 'proxy-client-svelte'
 	};
 </script>
 
-<svelte:component this={FlagProvider} {config}>
+<FlagProvider {config}>
 	<HelloWorld />
-</svelte:component>
+</FlagProvider>


### PR DESCRIPTION
Gives some much needed love to our Svelte SDK.

 - Fixes package by specifying a `main` entrypoint file (addresses https://unleash-community.slack.com/archives/C03GWTN7XMG/p1690904817968819?thread_ts=1690901590.794409&cid=C03GWTN7XMG);
 - Updates README to be aligned with the more up-to-date [proxy-client-react](https://github.com/Unleash/proxy-client-react) README (addresses https://unleash-community.slack.com/archives/C03GWTN7XMG/p1690913057754949?thread_ts=1690901590.794409&cid=C03GWTN7XMG);
 - Types the context for better type safety;
 - Connects the built-in demo to our demo instance;
 - Improves the built-in demo styling;
 - Misc improvements and refactors;

IMO this should make the SDK good enough for a 0.1.0 release after this gets merged.