### PR TITLE
feat: add feature_enabled property to variant response

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"vite": "^4.4.2"
 	},
 	"dependencies": {
-		"unleash-proxy-client": "^2.5.0"
+		"unleash-proxy-client": "^3.2.0"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/src/components/HelloWorld.svelte
+++ b/src/components/HelloWorld.svelte
@@ -4,6 +4,8 @@
 	const enabled = useFlag('svelte-test-feature');
 	const variant = useVariant('svelte-test-feature');
 	const { flagsReady } = useFlagsStatus();
+
+	$: if ($flagsReady) console.table({ $enabled, $variant });
 </script>
 
 <main>
@@ -14,6 +16,7 @@
 	{:else}
 		<p style={`font-size:24px; color: ${$enabled ? 'green' : 'red'}`}>
 			{$enabled ? 'Feature is enabled!' : 'Feature is disabled!'}
+			{$variant.feature_enabled}
 			{#if $variant.enabled}
 				<p>{$variant.name}</p>
 			{/if}

--- a/src/components/HelloWorld.svelte
+++ b/src/components/HelloWorld.svelte
@@ -16,7 +16,6 @@
 	{:else}
 		<p style={`font-size:24px; color: ${$enabled ? 'green' : 'red'}`}>
 			{$enabled ? 'Feature is enabled!' : 'Feature is disabled!'}
-			{$variant.feature_enabled}
 			{#if $variant.enabled}
 				<p>{$variant.name}</p>
 			{/if}

--- a/src/lib/useVariant.ts
+++ b/src/lib/useVariant.ts
@@ -1,6 +1,18 @@
 import { getContext } from 'svelte';
 import { writable, get } from 'svelte/store';
 import { ContextStateSymbol, type TContext } from './context.js';
+import type { IVariant } from 'unleash-proxy-client';
+
+const variantHasChanged = (oldVariant: IVariant, newVariant?: IVariant): boolean => {
+	const variantsAreEqual =
+		oldVariant.name === newVariant?.name &&
+		oldVariant.enabled === newVariant?.enabled &&
+		oldVariant.feature_enabled === newVariant?.feature_enabled &&
+		oldVariant.payload?.type === newVariant?.payload?.type &&
+		oldVariant.payload?.value === newVariant?.payload?.value;
+
+	return !variantsAreEqual;
+};
 
 const useVariant = (name: string) => {
 	const { getVariant, client } = getContext<TContext>(ContextStateSymbol);
@@ -12,7 +24,7 @@ const useVariant = (name: string) => {
 	const updateVariantValue = () => {
 		const newVariant = getVariant(name);
 		const currentVariant = get(variantStore);
-		if (newVariant?.name !== currentVariant.name || newVariant.enabled !== currentVariant.enabled) {
+		if (variantHasChanged(currentVariant, newVariant)) {
 			variantStore.set(newVariant!);
 		}
 	};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,13 +1687,13 @@ undici@~5.26.2:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-unleash-proxy-client@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz#0f4f34285bc3223023ca2cf3ef9dabd2132eea9f"
-  integrity sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==
+unleash-proxy-client@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz#cdecf1b3bdd40fbe7a20fd66c27906b33e53c4fd"
+  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
   dependencies:
     tiny-emitter "^2.1.0"
-    uuid "^8.3.2"
+    uuid "^9.0.1"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -1707,10 +1707,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 vite@^4.4.2:
   version "4.5.0"


### PR DESCRIPTION
Bumps `unleash-proxy-client` to `3.2.0` and makes the necessary adjustments for the new "feature_enabled" property.

![image](https://github.com/Unleash/proxy-client-svelte/assets/14320932/40e82931-457a-4616-89d2-9a9c7fa55916)