### PR TITLE
feat(1-3230):   add uniqueness headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"vite": "^4.4.2"
 	},
 	"dependencies": {
-		"unleash-proxy-client": "^3.2.0"
+		"unleash-proxy-client": "^3.7.1"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@ undici@~5.26.2:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-unleash-proxy-client@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz"
-  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
+unleash-proxy-client@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
+  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
Updates the dependency on the underlying Unleash client to 3.7.1. This
version of the client adds new x-unleash headers which lets Unleash
count unique connections and see SDK version information.