### PR TITLE
fix: update proxy client dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"vite": "^4.4.2"
 	},
 	"dependencies": {
-		"unleash-proxy-client": "^3.7.1"
+		"unleash-proxy-client": "^3.7.2"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@ undici@~5.26.2:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-unleash-proxy-client@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
-  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
+unleash-proxy-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.2.tgz#c6166bbaf293f8dea12cf65d061d72234c5b76a8"
+  integrity sha512-1SvHsl3kQh1DT9EKMQsN9alOvXZEz9hpxa3mG6QWtTmXJqa6VZi25dQ2U8Y2KAULKg6ARLMUQkod74Fe/pKp0g==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
This update includes uuid generation that doesn't rely on the `crypto` module for connection id.