### PR TITLE
chore: report SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@unleash/proxy-client-svelte",
-	"version": "0.4.2",
+	"version": "1.0.0",
 	"description": "Svelte interface for working with Unleash",
 	"repository": {
 		"type": "git",
@@ -50,7 +50,7 @@
 		"vite": "^4.4.2"
 	},
 	"dependencies": {
-		"unleash-proxy-client": "^3.7.2"
+		"unleash-proxy-client": "^4.0.0"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/src/lib/FlagProvider.svelte
+++ b/src/lib/FlagProvider.svelte
@@ -4,24 +4,26 @@
 	import { UnleashClient } from 'unleash-proxy-client';
 	import type { IConfig, IContext } from 'unleash-proxy-client';
 	import { get, writable } from 'svelte/store';
+	import { sdkVersion } from './version.js';
 
 	export let config: IConfig | undefined = undefined;
 	export let unleashClient: UnleashClient | undefined = undefined;
 	export let startClient = true;
 
-	let client = writable<UnleashClient | undefined>(unleashClient);
+	let client = writable<UnleashClient | undefined>();
 	let flagsReady = writable(false);
 	let flagsError = writable(null);
 
-	if (!config && !unleashClient) {
+	if (unleashClient) {
+		unleashClient.setSdkVersion(sdkVersion);
+		client.set(unleashClient);
+	} else if (config) {
+		client.set(new UnleashClient({ ...config, sdkVersion }));
+	} else {
 		console.warn(
 			`You must provide either a config or an unleash client to the flag provider. If you are initializing the client in useEffect, you can avoid this warning by
       checking if the client exists before rendering.`
 		);
-	}
-
-	if (!get(client) && config) {
-		client.set(new UnleashClient(config));
 	}
 
 	const currentClient = get(client);

--- a/src/lib/env.d.ts
+++ b/src/lib/env.d.ts
@@ -1,0 +1,1 @@
+declare const __VERSION__: string;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const sdkVersion = `unleash-svelte-sdk:${__VERSION__}`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import pkg from './package.json';
 
 export default defineConfig({
+	define: {
+		__VERSION__: pkg.version
+	},
 	plugins: [sveltekit()]
 });


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3762/proper-frontend-sdk-name-reporting

Follow-up to: https://github.com/Unleash/unleash-js-sdk/pull/259

Passes through the Svelte SDK version.